### PR TITLE
Output validation

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "lint:eslint": "eslint . --ext .ts,.tsx -f unix",
     "lint:prettier": "prettier --check src/**/*.ts tests/**/*.ts",
     "lint:unused-exports": "ts-unused-exports tsconfig.json --showLineNumber --excludePathsFromReport=util/*",
-    "testenv:run": "docker-compose -f ../docker/docker-compose.dev.postgres.yml up",
+    "testenv:run": "docker-compose -f ../docker/docker-compose.dev.postgres.yml up -d",
     "testenv:stop": "docker-compose -f ../docker/docker-compose.dev.postgres.yml down -v -t 0",
     "testenv:logs": "docker-compose -f ../docker/docker-compose.dev.postgres.yml logs -t -f"
   },

--- a/api/src/api/routes/transactions.ts
+++ b/api/src/api/routes/transactions.ts
@@ -2,7 +2,7 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
-import { LimitSchema, OffsetSchema, ActivityResponseSchema, TransactionIdSchema } from '../schemas';
+import { LimitSchema, OffsetSchema, ActivityResponseSchema, TransactionIdSchema, ValidOutputResponseSchema, AddressSchema, VoutSchema } from '../schemas';
 import { parseActivityResponse } from '../util/helpers';
 import { Optional, PaginatedResponse } from '@hirosystems/api-toolkit';
 import { handleCache } from '../util/cache';
@@ -46,6 +46,36 @@ export const TransactionRoutes: FastifyPluginCallback<
       });
     }
   );
+
+  fastify.get(
+    '/transactions/:tx_id/is-valid-ouptut',
+    {
+      schema: {
+        operationId: 'isValidOutput',
+        summary: 'Validates output',
+        description: 'Validates the output of the given transaction for certain address',
+        tags: ['Output'],
+        params: Type.Object({
+          tx_id: TransactionIdSchema,
+          
+        }),
+        querystring: Type.Object({
+          address: AddressSchema,
+          vout: VoutSchema,
+        }),
+        response: {
+          200: ValidOutputResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const results = await fastify.db.outputExists(request.params.tx_id, request.query.address, request.query.vout);
+      await reply.send({
+        is_valid: results,
+      });
+    }
+  );
+
 
   done();
 };

--- a/api/src/api/routes/transactions.ts
+++ b/api/src/api/routes/transactions.ts
@@ -62,6 +62,8 @@ export const TransactionRoutes: FastifyPluginCallback<
         querystring: Type.Object({
           address: AddressSchema,
           vout: VoutSchema,
+          offset: Optional(OffsetSchema),
+          limit: Optional(LimitSchema),
         }),
         response: {
           200: PaginatedResponse(ActivityResponseSchema, 'Paginated activity response'),
@@ -69,10 +71,12 @@ export const TransactionRoutes: FastifyPluginCallback<
       },
     },
     async (request, reply) => {
+      const offset = request.query.offset ?? 0;
+      const limit = request.query.limit ?? 20;
       const results = await fastify.db.getUtxoOfOutput(request.params.tx_id, request.query.address, request.query.vout);
       await reply.send({
-        limit: 1,
-        offset: 0,
+        limit: limit,
+        offset: offset,
         total: results.length,
         results: results.map(r => parseActivityResponse(r))
       });

--- a/api/src/api/routes/transactions.ts
+++ b/api/src/api/routes/transactions.ts
@@ -48,7 +48,7 @@ export const TransactionRoutes: FastifyPluginCallback<
   );
 
   fastify.get(
-    '/transactions/:tx_id/is-valid-ouptut',
+    '/transactions/:tx_id/valid-ouptut',
     {
       schema: {
         operationId: 'isValidOutput',

--- a/api/src/api/schemas.ts
+++ b/api/src/api/schemas.ts
@@ -384,3 +384,19 @@ export const NotFoundResponse = Type.Object(
   },
   { title: 'Not Found Response' }
 );
+
+
+export const VoutSchema = Type.Integer({
+    examples: [100],
+    title: 'Output index',
+    description: 'Bitcoin transaction output index',
+});
+
+export type Vout = Static<typeof VoutSchema>;
+
+export const ValidOutputResponseSchema = Type.Object({
+      is_valid: Type.Boolean({
+        title: 'Output is valid',
+        description: 'Combination of tx_idx, address and vout exists in recorded history',
+      }),
+});

--- a/api/src/api/util/helpers.ts
+++ b/api/src/api/util/helpers.ts
@@ -82,7 +82,7 @@ export function parseActivityResponse(entry: DbItemWithRune<DbLedgerEntry>): Act
       tx_index: entry.tx_index,
       tx_id: entry.tx_id,
       vout: entry.output ?? undefined,
-      output: entry.output ? `${entry.tx_id}:${entry.output}` : undefined,
+      output: entry.output !== null && entry.output !== undefined ? `${entry.tx_id}:${entry.output}` : undefined,
       timestamp: entry.timestamp,
     },
   };

--- a/api/src/pg/pg-store.ts
+++ b/api/src/pg/pg-store.ts
@@ -287,7 +287,7 @@ export class PgStore extends BasePgStore {
   ): Promise<DbItemWithRune<DbLedgerEntry>[]> {
 
     const result = await this.sql<DbItemWithRune<DbLedgerEntry>[]>`
-      SELECT l.*, r.name, r.number, r.spaced_name, r.divisibility
+      SELECT DISTINCT ON (rune_id) l.*, r.name, r.number, r.spaced_name, r.divisibility
       FROM ledger AS l
       INNER JOIN runes AS r ON r.id = l.rune_id
       WHERE l.tx_id = ${txId}

--- a/api/src/pg/pg-store.ts
+++ b/api/src/pg/pg-store.ts
@@ -25,6 +25,7 @@ import {
   RuneSpacedNameSchemaCType,
   TransactionId,
   RuneNumberSchemaCType,
+  Vout,
 } from '../api/schemas';
 
 function runeFilter(sql: PgSqlClient, etching: string, prefix?: string): PgSqlQuery {
@@ -277,5 +278,21 @@ export class PgStore extends BasePgStore {
       total: results[0]?.total ?? 0,
       results,
     };
+  }
+
+  async outputExists(
+    txId: TransactionId,
+    address: Address,
+    vout: Vout, 
+  ): Promise<boolean> {
+    const result = await this.sql<{exists : boolean}[]>`
+    SELECT EXISTS (
+      SELECT 1 FROM ledger
+      WHERE tx_id = ${txId}
+        AND address = ${address}
+        AND output = ${vout ?? this.sql`NULL`}
+    )
+    `;
+    return result[0]?.exists;
   }
 }

--- a/api/src/pg/pg-store.ts
+++ b/api/src/pg/pg-store.ts
@@ -280,19 +280,20 @@ export class PgStore extends BasePgStore {
     };
   }
 
-  async outputExists(
+  async getUtxoOfOutput(
     txId: TransactionId,
     address: Address,
     vout: Vout, 
-  ): Promise<boolean> {
-    const result = await this.sql<{exists : boolean}[]>`
-    SELECT EXISTS (
-      SELECT 1 FROM ledger
-      WHERE tx_id = ${txId}
-        AND address = ${address}
-        AND output = ${vout ?? this.sql`NULL`}
-    )
+  ): Promise<DbItemWithRune<DbLedgerEntry>[]> {
+
+    const result = await this.sql<DbItemWithRune<DbLedgerEntry>[]>`
+      SELECT l.*, r.name, r.number, r.spaced_name, r.divisibility
+      FROM ledger AS l
+      INNER JOIN runes AS r ON r.id = l.rune_id
+      WHERE l.tx_id = ${txId}
+        AND l.address = ${address}
+        AND l.output = ${vout}
     `;
-    return result[0]?.exists;
+    return result;
   }
 }

--- a/api/tests/api/api.test.ts
+++ b/api/tests/api/api.test.ts
@@ -161,7 +161,7 @@ describe('Endpoints', () => {
               total_operations: 1,
             };
             const expected = {
-              limit: 1,
+              limit: 20,
               offset: 0,
               results: [
                 parseActivityResponse(expectedDbRes)
@@ -181,7 +181,7 @@ describe('Endpoints', () => {
     
         test("validate output, no match", async () => {
           const expected = {
-            limit: 1,
+            limit: 20,
             offset: 0,
             results: [],
             total: 0,

--- a/api/tests/api/api.test.ts
+++ b/api/tests/api/api.test.ts
@@ -147,5 +147,31 @@ describe('Endpoints', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json()).toStrictEqual(expected);
     });
+    
+        test("validate output success", async () => {
+            const expected = {is_valid: true};
+            const txid = ledgerEntry.tx_id;
+            const response = await fastify.inject({
+              method: 'GET',
+              url: '/runes/v1/transactions/' + txid + '/is-valid-ouptut',
+              query: {address: `${ledgerEntry.address}`, vout : `${ledgerEntry.output}`},
+            });
+
+            expect(response.statusCode).toBe(200);
+            expect(response.json()).toStrictEqual(expected);
+          });
+    
+        test("validate output, no match", async () => {
+          const expected = {is_valid: false};
+          const txid = ledgerEntry.tx_id;
+          const response = await fastify.inject({
+            method: 'GET',
+            url: '/runes/v1/transactions/' + txid + '/is-valid-ouptut',
+            query: {address: `${ledgerEntry.address}`, vout : `${42}`},
+          });
+
+          expect(response.statusCode).toBe(200);
+          expect(response.json()).toStrictEqual(expected);
+        });
   });
 });

--- a/api/tests/api/api.test.ts
+++ b/api/tests/api/api.test.ts
@@ -171,7 +171,7 @@ describe('Endpoints', () => {
             const txid = ledgerEntry.tx_id;
             const response = await fastify.inject({
               method: 'GET',
-              url: '/runes/v1/transactions/' + txid + '/is-valid-ouptut',
+              url: '/runes/v1/transactions/' + txid + '/valid-ouptut',
               query: {address: `${ledgerEntry.address}`, vout : `${ledgerEntry.output}`},
             });
 
@@ -189,7 +189,7 @@ describe('Endpoints', () => {
           const txid = ledgerEntry.tx_id;
           const response = await fastify.inject({
             method: 'GET',
-            url: '/runes/v1/transactions/' + txid + '/is-valid-ouptut',
+            url: '/runes/v1/transactions/' + txid + '/valid-ouptut',
             query: {address: `${ledgerEntry.address}`, vout : `${42}`},
           });
 

--- a/api/tests/helpers.ts
+++ b/api/tests/helpers.ts
@@ -87,7 +87,7 @@ export function sampleRune(id: string, name?: string): DbRune {
     block_height: '840000',
     tx_index: 1,
     tx_id: '2bb85f4b004be6da54f766c17c1e855187327112c231ef2ff35ebad0ea67c69e',
-    divisibility: 2,
+    divisibility: 0,
     premine: '1000',
     symbol: 'ᚠ',
     cenotaph: true,
@@ -165,6 +165,7 @@ export async function insertSupplyChange(
   });
 }
 
+// inserting not all Fields to the DB
 export async function insertRune(db: PgStore, payload: DbRune): Promise<void> {
   await db.sqlWriteTransaction(async sql => {
     const {

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,5 +1,7 @@
 // ts-unused-exports:disable-next-line
 export default (): void => {
+  process.env.PGHOST = 'localhost';
+  process.env.PGUSER = 'postgres';
   process.env.PGDATABASE = 'postgres';
   process.env.PGPASSWORD = 'postgres';
 };


### PR DESCRIPTION
- made npm `testenv:run` scenario non-blocking 
- fixed tests setup
- implemented new output validation handler to `transactions` routes group
- added tests covering the output validation scenario