### PR TITLE
Implemented last block height retrieval

### DIFF
--- a/api/src/api/routes/blocks.ts
+++ b/api/src/api/routes/blocks.ts
@@ -2,7 +2,13 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
-import { LimitSchema, OffsetSchema, ActivityResponseSchema, BlockSchema } from '../schemas';
+import {
+  LimitSchema,
+  OffsetSchema,
+  ActivityResponseSchema,
+  BlockSchema,
+  BlockHeightResponseSchema,
+} from '../schemas';
 import { parseActivityResponse } from '../util/helpers';
 import { Optional, PaginatedResponse } from '@hirosystems/api-toolkit';
 import { handleCache } from '../util/cache';
@@ -43,6 +49,27 @@ export const BlockRoutes: FastifyPluginCallback<
         offset,
         total: results.total,
         results: results.results.map(r => parseActivityResponse(r)),
+      });
+    }
+  );
+
+  fastify.get(
+    '/blocks/height',
+    {
+      schema: {
+        operationId: 'getBlockHeight',
+        summary: 'Last scanned block height',
+        description: 'Retrieves a the height of the last scanned block',
+        tags: ['Status'],
+        response: {
+          200: BlockHeightResponseSchema,
+        },
+      },
+    },
+    async (_request, reply) => {
+      const results = await fastify.db.getLastScannedBlockHeigt();
+      await reply.send({
+        last_scanned_height: results.last_scanned_height,
       });
     }
   );

--- a/api/src/api/schemas.ts
+++ b/api/src/api/schemas.ts
@@ -426,3 +426,9 @@ export const AmountOutputResponseSchema = Type.Object({
 });
 
 export type AmountOutputResponse = Static<typeof AmountOutputResponseSchema>;
+
+export const BlockHeightResponseSchema = Type.Object({
+  last_scanned_height: Type.Number(),
+});
+
+export type BlockHeightResponseSchema = Static<typeof BlockHeightResponseSchema>;

--- a/api/src/pg/pg-store.ts
+++ b/api/src/pg/pg-store.ts
@@ -9,6 +9,7 @@ import { ENV } from '../env';
 import {
   DbAmountChange,
   DbBalance,
+  DbBlockHeight,
   DbCountedQueryResult,
   DbItemWithRune,
   DbLedgerEntry,
@@ -311,5 +312,13 @@ export class PgStore extends BasePgStore {
         AND l.rune_id = ${runeId}
     `;
     return result;
+  }
+
+  async getLastScannedBlockHeigt(): Promise<DbBlockHeight> {
+    const result = await this.sql<DbBlockHeight[]>`
+        SELECT last_scanned_height FROM block_height LIMIT 1
+    `;
+    // there would be at least one value inserted by default
+    return result[0];
   }
 }

--- a/api/src/pg/types.ts
+++ b/api/src/pg/types.ts
@@ -71,3 +71,7 @@ export type DbAmountChange = {
   amount: string;
   divisibility: number;
 };
+
+export type DbBlockHeight = {
+  last_scanned_height: number;
+};

--- a/migrations/V5__block_height.sql
+++ b/migrations/V5__block_height.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS block_height (
+    last_scanned_height NUMERIC
+);
+
+INSERT INTO block_height (last_scanned_height)
+SELECT 0
+WHERE NOT EXISTS (SELECT 1 FROM block_height);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -521,6 +521,26 @@ pub async fn pg_get_input_rune_balances(
     results
 }
 
+pub async fn pg_update_block_height(
+    new_block_height: u64,
+    db_tx: &mut Transaction<'_>,
+    ctx: &Context,
+) -> Result<(), Error> {
+    match db_tx
+        .query_one(
+            "UPDATE block_height SET last_scanned_height = $1;",
+            &[&PgNumericU64(new_block_height)],
+        )
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            try_error!(ctx, "Error updating block height: {:?}", e);
+        }
+    };
+    Ok(())
+}
+
 #[cfg(test)]
 pub async fn pg_test_client(run_migrations: bool, ctx: &Context) -> Client {
     let (mut client, connection) =


### PR DESCRIPTION
Added:
- A new single-row table `block_height` with a single `NUMERIC` column l`ast_scanned_height,` containing the last scanned block height.
- The value in the table updates once the block scanning is complete.
- A new API handler in the `blocks` group to retrieve this value."